### PR TITLE
Add completions mailer

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
+  default from: "notifications@beproductivemaybe.com"
+  layout "mailer"
 end

--- a/app/mailers/completions_mailer.rb
+++ b/app/mailers/completions_mailer.rb
@@ -1,0 +1,9 @@
+class CompletionsMailer < ApplicationMailer
+  def notify(task)
+    @task = task
+    mail(
+      to: task.user.email,
+      subject: t(".notify.subject", description: task.description),
+    )
+  end
+end

--- a/app/views/completions_mailer/notify.html.slim
+++ b/app/views/completions_mailer/notify.html.slim
@@ -1,0 +1,5 @@
+p
+  = t(".prompt", description: @task.description)
+
+p
+  = link_to t(".complete"), task_completion_url(@task)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,13 @@ en:
   completions:
     success: Task completed
 
+  completions_mailer:
+    notify:
+      complete: I did it!
+      prompt: >
+        If you're feeling up to it, you should %{description}.
+      subject: Hey, maybe %{description}?
+
   date:
     formats:
       default:

--- a/spec/mailers/completions_mailer_spec.rb
+++ b/spec/mailers/completions_mailer_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe CompletionsMailer do
+  describe "#notify" do
+    it "notifies the user to complete the given task" do
+      task = create(:task)
+
+      mail = CompletionsMailer.notify(task)
+
+      expect(mail.subject).to eq t(
+        "completions_mailer.notify.subject",
+        description: task.description,
+      )
+      expect(mail.to).to eq [task.user.email]
+      expect(mail.body).to include task_completion_url(task)
+    end
+  end
+end

--- a/spec/mailers/previews/completions_mailer_preview.rb
+++ b/spec/mailers/previews/completions_mailer_preview.rb
@@ -1,0 +1,6 @@
+class CompletionsMailerPreview < ActionMailer::Preview
+  def notify
+    task = FactoryGirl.create(:task, description: "dust the living room")
+    CompletionsMailer.notify(task)
+  end
+end


### PR DESCRIPTION
Users will be notified about tasks via email. This adds a mailer for
doing that and giving them a way to mark the task as completed. The
mailer isn't used anywhere yet.